### PR TITLE
Feat/schema to extended type

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -463,11 +463,9 @@ async def form_full(form_data: list[dict] = []):
             )
 
             # List of nested objects
-            education_history: unique_conlist(Education, min_items=1, max_items=5) = (
-                Field(
-                    title="Education history",
-                    description="Your educational background",
-                )
+            education_history: unique_conlist(Education, min_items=1, max_items=5) = Field(
+                title="Education history",
+                description="Your educational background",
             )
 
         nested_data = yield FullFormNested

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,7 +20,15 @@ from annotated_types import (
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, HttpUrl, IPvAnyAddress, Json
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    HttpUrl,
+    IPvAnyAddress,
+    Json,
+)
 from pydantic_forms.core import FormPage, post_form
 from pydantic_forms.types import State
 from pydantic_forms.exception_handlers.fastapi import form_error_handler
@@ -248,10 +256,10 @@ class Colors(Choice):
     VIOLET = ("#7C3AED", "Violet")
     YELLOW_DARK = ("#A16207", "Yellow Dark")
 
+
 @app.post("/form-full")
 async def form_full(form_data: list[dict] = []):
     def form_generator(state: State):
-
         # Page 1: Basic string and numeric types
         class FullFormBasicTypes(FormPage):
             model_config = ConfigDict(title="Basic Types - Strings and Numbers")
@@ -311,7 +319,9 @@ async def form_full(form_data: list[dict] = []):
             )
 
             # Literal
-            experience_level: Literal["beginner", "intermediate", "advanced", "expert"] = Field(
+            experience_level: Literal[
+                "beginner", "intermediate", "advanced", "expert"
+            ] = Field(
                 title="Experience level",
                 description="Select your skill level",
                 default="beginner",
@@ -435,7 +445,9 @@ async def form_full(form_data: list[dict] = []):
             model_config = ConfigDict(title="Nested Objects and Complex Types")
 
             class Address(BaseModel):
-                street: str = Field(title="Street", description="Street name and number")
+                street: str = Field(
+                    title="Street", description="Street name and number"
+                )
                 city: str = Field(title="City")
                 postal_code: str = Field(title="Postal code")
                 country: str = Field(title="Country")
@@ -452,9 +464,11 @@ async def form_full(form_data: list[dict] = []):
             )
 
             # List of nested objects
-            education_history: unique_conlist(Education, min_items=1, max_items=5) = Field(
-                title="Education history",
-                description="Your educational background",
+            education_history: unique_conlist(Education, min_items=1, max_items=5) = (
+                Field(
+                    title="Education history",
+                    description="Your educational background",
+                )
             )
 
         nested_data = yield FullFormNested
@@ -464,7 +478,9 @@ async def form_full(form_data: list[dict] = []):
             model_config = ConfigDict(title="Constrained Types with Validation")
 
             # Constrained string
-            username: Annotated[str, Field(min_length=3, max_length=20, pattern=r"^[a-zA-Z0-9_]+$")] = Field(
+            username: Annotated[
+                str, Field(min_length=3, max_length=20, pattern=r"^[a-zA-Z0-9_]+$")
+            ] = Field(
                 title="Username",
                 description="Alphanumeric username (3-20 characters)",
             )
@@ -482,9 +498,11 @@ async def form_full(form_data: list[dict] = []):
             )
 
             # Constrained list
-            priority_list: Annotated[list[int], Field(min_length=3, max_length=5)] = Field(
-                title="Priority list",
-                description="Rank your top 3-5 priorities",
+            priority_list: Annotated[list[int], Field(min_length=3, max_length=5)] = (
+                Field(
+                    title="Priority list",
+                    description="Rank your top 3-5 priorities",
+                )
             )
 
         validation_data = yield FullFormValidation
@@ -525,6 +543,7 @@ async def form_full(form_data: list[dict] = []):
 
 class SimpleChoices(Choice):
     """Simple choice options for demonstration."""
+
     OPTION_A = ("a", "Option A")
     OPTION_B = ("b", "Option B")
     OPTION_C = ("c", "Option C")
@@ -533,8 +552,8 @@ class SimpleChoices(Choice):
 @app.post("/form-simple")
 async def form_simple(form_data: list[dict] = []):
     """Simple form with only scalar field types - no arrays or objects."""
-    def form_generator(state: State):
 
+    def form_generator(state: State):
         class SimpleForm(SubmitFormPage):
             model_config = ConfigDict(title="Simple Form - Scalar Fields Only")
 
@@ -566,6 +585,37 @@ async def form_simple(form_data: list[dict] = []):
                 description="Select your date of birth",
             )
 
+            # Custom schema fields: rendered by the frontend as non-input UI blocks.
+            # json_schema_extra passes arbitrary data to the schema, which the frontend
+            # can read via pydanticFormField.schema in a custom component matcher.
+            # "format" determines which component matches; the rest is your own schema.
+            age_notice: Annotated[
+                str,
+                Field(
+                    default=None,
+                    exclude=True,
+                    json_schema_extra={
+                        "format": "note",
+                        "variant": "warning",
+                        "message": "You must be at least 18 years old to submit this form. Your age will be verified.",
+                    },
+                ),
+            ]
+
+            # Another custom field with a different variant and context
+            data_usage_notice: Annotated[
+                str,
+                Field(
+                    default=None,
+                    exclude=True,
+                    json_schema_extra={
+                        "format": "note",
+                        "variant": "info",
+                        "message": "Your name and date of birth are used solely for account verification and are not shared with third parties.",
+                    },
+                ),
+            ]
+
             # Boolean field
             subscribe: bool = Field(
                 title="Subscribe to Newsletter",
@@ -585,4 +635,3 @@ async def form_simple(form_data: list[dict] = []):
 
     post_form(form_generator, state={}, user_inputs=form_data)
     return "OK!"
-

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, ClassVar, Iterator, Literal
+from typing import Annotated, ClassVar, Iterator, Literal, Optional
 from uuid import UUID
 
 from annotated_types import (
@@ -14,7 +14,6 @@ from annotated_types import (
     Le,
     MultipleOf,
     Predicate,
-    doc,
 )
 
 from fastapi import FastAPI
@@ -590,7 +589,7 @@ async def form_simple(form_data: list[dict] = []):
             # can read via pydanticFormField.schema in a custom component matcher.
             # "format" determines which component matches; the rest is your own schema.
             age_notice: Annotated[
-                str,
+                Optional[str],
                 Field(
                     default=None,
                     exclude=True,
@@ -604,7 +603,7 @@ async def form_simple(form_data: list[dict] = []):
 
             # Another custom field with a different variant and context
             data_usage_notice: Annotated[
-                str,
+                Optional[str],
                 Field(
                     default=None,
                     exclude=True,

--- a/backend/main.py
+++ b/backend/main.py
@@ -556,7 +556,7 @@ class NoticeField(GroupedMetadata):
     def __iter__(self) -> Iterator[BaseMetadata]:
         yield Field(
             json_schema_extra={
-                "format": "note",
+                "format": "notice",
                 "variant": self.variant,
                 "message": self.message,
             },

--- a/backend/main.py
+++ b/backend/main.py
@@ -555,8 +555,6 @@ class NoticeField(GroupedMetadata):
 
     def __iter__(self) -> Iterator[BaseMetadata]:
         yield Field(
-            default=None,
-            exclude=True,
             json_schema_extra={
                 "format": "note",
                 "variant": self.variant,
@@ -617,13 +615,13 @@ async def form_simple(form_data: list[dict] = []):
             # json_schema_extra passes arbitrary data to the schema, which the frontend
             # can read via pydanticFormField.schema in a custom component matcher.
             # "format" determines which component matches; the rest is your own schema.
-            age_notice: Annotated[Optional[str], _age_notice]
+            age_notice: Annotated[Optional[str], _age_notice] = None
 
             # Another custom field with a different variant and context
             data_usage_notice: Annotated[
                 Optional[str],
                 _data_usage_notice,
-            ]
+            ] = None
 
             # Boolean field
             subscribe: bool = Field(

--- a/backend/main.py
+++ b/backend/main.py
@@ -548,6 +548,35 @@ class SimpleChoices(Choice):
     OPTION_C = ("c", "Option C")
 
 
+@dataclass(frozen=True, **SLOTS)
+class NoticeField(GroupedMetadata):
+    variant: str  # can also be made into a Enum for specific variants
+    message: str
+
+    def __iter__(self) -> Iterator[BaseMetadata]:
+        yield Field(
+            default=None,
+            exclude=True,
+            json_schema_extra={
+                "format": "note",
+                "variant": self.variant,
+                "message": self.message,
+            },
+        )
+
+
+_age_notice = NoticeField(
+    variant="warning",
+    message="You must be at least 18 years old to submit this form. Your age will be verified.",
+)
+
+
+_data_usage_notice = NoticeField(
+    variant="info",
+    message="Your name and date of birth are used solely for account verification and are not shared with third parties.",
+)
+
+
 @app.post("/form-simple")
 async def form_simple(form_data: list[dict] = []):
     """Simple form with only scalar field types - no arrays or objects."""
@@ -588,31 +617,12 @@ async def form_simple(form_data: list[dict] = []):
             # json_schema_extra passes arbitrary data to the schema, which the frontend
             # can read via pydanticFormField.schema in a custom component matcher.
             # "format" determines which component matches; the rest is your own schema.
-            age_notice: Annotated[
-                Optional[str],
-                Field(
-                    default=None,
-                    exclude=True,
-                    json_schema_extra={
-                        "format": "note",
-                        "variant": "warning",
-                        "message": "You must be at least 18 years old to submit this form. Your age will be verified.",
-                    },
-                ),
-            ]
+            age_notice: Annotated[Optional[str], _age_notice]
 
             # Another custom field with a different variant and context
             data_usage_notice: Annotated[
                 Optional[str],
-                Field(
-                    default=None,
-                    exclude=True,
-                    json_schema_extra={
-                        "format": "note",
-                        "variant": "info",
-                        "message": "Your name and date of birth are used solely for account verification and are not shared with third parties.",
-                    },
-                ),
+                _data_usage_notice,
             ]
 
             # Boolean field

--- a/backend/main.py
+++ b/backend/main.py
@@ -497,11 +497,9 @@ async def form_full(form_data: list[dict] = []):
             )
 
             # Constrained list
-            priority_list: Annotated[list[int], Field(min_length=3, max_length=5)] = (
-                Field(
-                    title="Priority list",
-                    description="Rank your top 3-5 priorities",
-                )
+            priority_list: Annotated[list[int], Field(min_length=3, max_length=5)] = Field(
+                title="Priority list",
+                description="Rank your top 3-5 priorities",
             )
 
         validation_data = yield FullFormValidation

--- a/frontend/apps/example-tailwind/src/components/fields/tailwind/HelpBanner.tsx
+++ b/frontend/apps/example-tailwind/src/components/fields/tailwind/HelpBanner.tsx
@@ -1,0 +1,43 @@
+import { AlertCircle, AlertTriangle, CheckCircle, Info } from 'lucide-react';
+import { PydanticFormElementProps } from 'pydantic-forms';
+
+type Variant = 'info' | 'warning' | 'error' | 'success';
+
+type HelpBannerSchema = {
+    message: string;
+    variant?: Variant;
+};
+
+const variantConfig: Record<Variant, { styles: string; Icon: typeof Info }> = {
+    info: {
+        styles: 'bg-indigo-50 border-indigo-200 text-indigo-800 dark:bg-indigo-950/40 dark:border-indigo-800 dark:text-indigo-300',
+        Icon: Info,
+    },
+    warning: {
+        styles: 'bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-950/40 dark:border-amber-800 dark:text-amber-300',
+        Icon: AlertTriangle,
+    },
+    error: {
+        styles: 'bg-red-50 border-red-200 text-red-800 dark:bg-red-950/40 dark:border-red-800 dark:text-red-300',
+        Icon: AlertCircle,
+    },
+    success: {
+        styles: 'bg-emerald-50 border-emerald-200 text-emerald-800 dark:bg-emerald-950/40 dark:border-emerald-800 dark:text-emerald-300',
+        Icon: CheckCircle,
+    },
+};
+
+export const HelpBanner = ({
+    pydanticFormField,
+}: PydanticFormElementProps<HelpBannerSchema>) => {
+    const { message, variant = 'info' } = pydanticFormField.schema;
+    const { styles, Icon } = variantConfig[variant];
+    return (
+        <div
+            className={`flex items-start my-5 gap-2.5 rounded-lg border px-4 py-3 text-sm ${styles}`}
+        >
+            <Icon className="mt-0.5 size-4 shrink-0" />
+            <span>{message}</span>
+        </div>
+    );
+};

--- a/frontend/apps/example-tailwind/src/components/fields/tailwind/index.ts
+++ b/frontend/apps/example-tailwind/src/components/fields/tailwind/index.ts
@@ -1,5 +1,6 @@
 export { CheckboxField } from './CheckboxField';
 export { DateField } from './DateField';
+export { HelpBanner } from './HelpBanner';
 export { DateTimeField } from './DateTimeField';
 export { DividerField } from './DividerField';
 export { DropdownField } from './DropdownField';

--- a/frontend/apps/example-tailwind/src/shared/componentMatcher.ts
+++ b/frontend/apps/example-tailwind/src/shared/componentMatcher.ts
@@ -117,7 +117,7 @@ export const createComponentMatcher = (
             },
         },
         {
-            id: 'note',
+            id: 'notice',
             ElementMatch: {
                 Element: HelpBanner,
                 isControlledElement: false,

--- a/frontend/apps/example-tailwind/src/shared/componentMatcher.ts
+++ b/frontend/apps/example-tailwind/src/shared/componentMatcher.ts
@@ -123,7 +123,7 @@ export const createComponentMatcher = (
                 isControlledElement: false,
             },
             matcher(field) {
-                return field.schema.format === 'note';
+                return field.schema.format === 'notice';
             },
         },
         {

--- a/frontend/apps/example-tailwind/src/shared/componentMatcher.ts
+++ b/frontend/apps/example-tailwind/src/shared/componentMatcher.ts
@@ -11,6 +11,7 @@ import {
     DateField,
     DateTimeField,
     DropdownField,
+    HelpBanner,
     IntegerField,
     RadioField,
     TextAreaField,
@@ -113,6 +114,16 @@ export const createComponentMatcher = (
             },
             matcher(field) {
                 return field.type === PydanticFormFieldType.BOOLEAN;
+            },
+        },
+        {
+            id: 'note',
+            ElementMatch: {
+                Element: HelpBanner,
+                isControlledElement: false,
+            },
+            matcher(field) {
+                return field.schema.format === 'note';
             },
         },
         {

--- a/frontend/packages/pydantic-forms/src/core/index.ts
+++ b/frontend/packages/pydantic-forms/src/core/index.ts
@@ -5,3 +5,4 @@ export * from './getMatcher';
 export * from './getPydanticFormComponents';
 export * from './getClientSideValidationRule';
 export * from './fieldToComponentMatcher';
+export * from './WrapFieldElement';

--- a/frontend/packages/pydantic-forms/src/types.ts
+++ b/frontend/packages/pydantic-forms/src/types.ts
@@ -17,7 +17,9 @@ export type PydanticFormFieldValue = any;
 export type PydanticFormElementProps<
     TSchema extends object = PydanticFormPropertySchemaParsed,
 > = {
-    pydanticFormField: Omit<PydanticFormField, 'schema'> & { schema: TSchema };
+    pydanticFormField: Omit<PydanticFormField, 'schema'> & {
+        schema: PydanticFormPropertySchemaParsed & TSchema;
+    };
 };
 
 export type PydanticFormElement =

--- a/frontend/packages/pydantic-forms/src/types.ts
+++ b/frontend/packages/pydantic-forms/src/types.ts
@@ -22,15 +22,15 @@ export type PydanticFormElementProps<
     };
 };
 
-export type PydanticFormElement =
-    React.JSXElementConstructor<PydanticFormElementProps>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PydanticFormElement = React.JSXElementConstructor<PydanticFormElementProps<any>>;
 
 export type PydanticFormControlledElementProps<
     TSchema extends object = PydanticFormPropertySchemaParsed,
 > = Omit<ControllerRenderProps, 'ref'> & PydanticFormElementProps<TSchema>;
 
-export type PydanticFormControlledElement =
-    React.JSXElementConstructor<PydanticFormControlledElementProps>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PydanticFormControlledElement = React.JSXElementConstructor<PydanticFormControlledElementProps<any>>;
 
 export type PydanticFormFieldDataStorage = {
     set: (fieldId: string, key: string | number, value: unknown) => void;

--- a/frontend/packages/pydantic-forms/src/types.ts
+++ b/frontend/packages/pydantic-forms/src/types.ts
@@ -14,18 +14,18 @@ export type PydanticFormMetaData = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type PydanticFormFieldValue = any;
 
-export type PydanticFormElementProps = {
-    pydanticFormField: PydanticFormField;
+export type PydanticFormElementProps<
+    TSchema extends object = PydanticFormPropertySchemaParsed,
+> = {
+    pydanticFormField: Omit<PydanticFormField, 'schema'> & { schema: TSchema };
 };
 
 export type PydanticFormElement =
     React.JSXElementConstructor<PydanticFormElementProps>;
 
-export type PydanticFormControlledElementProps = Omit<
-    ControllerRenderProps,
-    'ref'
-> &
-    PydanticFormElementProps;
+export type PydanticFormControlledElementProps<
+    TSchema extends object = PydanticFormPropertySchemaParsed,
+> = Omit<ControllerRenderProps, 'ref'> & PydanticFormElementProps<TSchema>;
 
 export type PydanticFormControlledElement =
     React.JSXElementConstructor<PydanticFormControlledElementProps>;
@@ -124,6 +124,10 @@ export enum PydanticFormFieldFormat {
     MARKDOWN = 'markdown',
     DIVIDER = 'divider',
 }
+
+export type PydanticFormFieldFormatExtended =
+    | PydanticFormFieldFormat
+    | (string & {});
 
 export interface PydanticFormFieldOption {
     value: string;
@@ -397,7 +401,7 @@ export interface PydanticFormPropertySchemaParsed
     };
 
     default?: string | null | object;
-    format?: PydanticFormFieldFormat;
+    format?: PydanticFormFieldFormatExtended;
     const?: number | string | boolean | null;
 
     uniforms?: UniformProperties;


### PR DESCRIPTION
Summary

  - Generic TSchema on element props — PydanticFormElementProps and
  PydanticFormControlledElementProps now accept an optional type
  parameter. When provided, it intersects with
  PydanticFormPropertySchemaParsed, giving full type safety on
  pydanticFormField.schema without any casting. Defaults to
  PydanticFormPropertySchemaParsed for full backward compatibility.
  - HelpBanner custom field component — A reference implementation
  showing the pattern end-to-end: a non-input field component with
  info, warning, error, and success variants, matched by format: "note"
   in the component matcher.
  - Backend example — The /form-simple endpoint demonstrates how to
  embed contextual UI blocks inline in a form using json_schema_extra,
  without the data being submitted.

  Why

  Custom field components (e.g. banners, info blocks, summaries) need
  to read their own structured data from pydanticFormField.schema.
  Previously the only option was to cast schema as MyType, which is
  friction for open-source consumers. The generic approach lets
  consumers define their schema shape once and get full autocomplete
  and type safety throughout:

```
  type HelpBannerSchema = {
      message: string;
      variant?: 'info' | 'warning' | 'error' | 'success';
  };

  const HelpBanner = ({ pydanticFormField }:
  PydanticFormElementProps<HelpBannerSchema>) => {
      const { message, variant, format } = pydanticFormField.schema; //
   all typed
  };
```

