### PR TITLE
223 fix multicheckbox matching

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,6 @@ from typing import Annotated, ClassVar, Iterator, Literal, Optional
 from uuid import UUID
 
 from annotated_types import (
-    SLOTS,
     BaseMetadata,
     GroupedMetadata,
     Ge,
@@ -77,7 +76,7 @@ def read_root():
     return {"Hello": "World"}
 
 
-@dataclass(frozen=True, **SLOTS)
+@dataclass(frozen=True)
 class ExtraData(GroupedMetadata):
     props: dict
 
@@ -544,7 +543,7 @@ class SimpleChoices(Choice):
     OPTION_C = ("c", "Option C")
 
 
-@dataclass(frozen=True, **SLOTS)
+@dataclass(frozen=True)
 class NoticeField(GroupedMetadata):
     variant: str  # can also be made into a Enum for specific variants
     message: str
@@ -622,7 +621,7 @@ async def form_simple(form_data: list[dict] = []):
             # Boolean field
             subscribe: bool = Field(
                 title="Subscribe to Newsletter",
-                description="Check this box to receive our newsletter",
+                description="Check this box to receive` our newsletter",
                 default=False,
             )
 

--- a/frontend/.changeset/frank-ways-warn.md
+++ b/frontend/.changeset/frank-ways-warn.md
@@ -1,0 +1,5 @@
+---
+'pydantic-forms': minor
+---
+
+Fixes validation and matching for some array type fields

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19252,7 +19252,7 @@
             }
         },
         "packages/pydantic-forms": {
-            "version": "3.0.0",
+            "version": "3.0.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^14.2.1",

--- a/frontend/packages/pydantic-forms/src/components/defaultComponentMatchers.ts
+++ b/frontend/packages/pydantic-forms/src/components/defaultComponentMatchers.ts
@@ -4,24 +4,9 @@
  * We will search for the first field that returns a positive match
  */
 import _ from 'lodash';
-
 import type { PydanticComponentMatcher } from '../types';
 import { PydanticFormFieldFormat, PydanticFormFieldType } from '../types';
-import {
-    ArrayField,
-    CheckboxField,
-    DividerField,
-    DropdownField,
-    HiddenField,
-    IntegerField,
-    LabelField,
-    MultiCheckboxField,
-    MultiSelectField,
-    ObjectField,
-    RadioField,
-    TextAreaField,
-    TextField,
-} from './fields';
+import { ArrayField, CheckboxField, DividerField, DropdownField, HiddenField, IntegerField, LabelField, MultiCheckboxField, MultiSelectField, ObjectField, RadioField, TextAreaField, TextField } from './fields';
 import { zodValidationPresets } from './zodValidationsPresets';
 
 const defaultComponentMatchers: PydanticComponentMatcher[] = [
@@ -137,11 +122,13 @@ const defaultComponentMatchers: PydanticComponentMatcher[] = [
             isControlledElement: true,
         },
         matcher(field) {
+            const fieldOptions = field.arrayItem?.options
+
             return (
                 field.type === PydanticFormFieldType.ARRAY &&
-                _.isArray(field.options) &&
-                field.options?.length > 0 &&
-                field.options?.length <= 5
+                _.isArray(fieldOptions) &&
+                fieldOptions?.length > 0 &&
+                fieldOptions?.length <= 5
             );
         },
         validator: zodValidationPresets.multiSelect,
@@ -153,9 +140,11 @@ const defaultComponentMatchers: PydanticComponentMatcher[] = [
             isControlledElement: true,
         },
         matcher(field) {
+            const fieldOptions = field.arrayItem?.options
+
             return (
-                _.isArray(field.options) &&
-                field.options?.length > 0 &&
+                _.isArray(fieldOptions) &&
+                fieldOptions?.length > 0 &&
                 field.type === PydanticFormFieldType.ARRAY
             );
         },

--- a/frontend/packages/pydantic-forms/src/components/defaultComponentMatchers.ts
+++ b/frontend/packages/pydantic-forms/src/components/defaultComponentMatchers.ts
@@ -146,7 +146,6 @@ const defaultComponentMatchers: PydanticComponentMatcher[] = [
                 fieldOptions?.length <= 5
             );
         },
-        validator: zodValidationPresets.multiSelect,
     },
     {
         id: 'list',
@@ -163,7 +162,6 @@ const defaultComponentMatchers: PydanticComponentMatcher[] = [
                 field.type === PydanticFormFieldType.ARRAY
             );
         },
-        validator: zodValidationPresets.multiSelect,
     },
     {
         id: 'object',

--- a/frontend/packages/pydantic-forms/src/components/defaultComponentMatchers.ts
+++ b/frontend/packages/pydantic-forms/src/components/defaultComponentMatchers.ts
@@ -4,9 +4,24 @@
  * We will search for the first field that returns a positive match
  */
 import _ from 'lodash';
+
 import type { PydanticComponentMatcher } from '../types';
 import { PydanticFormFieldFormat, PydanticFormFieldType } from '../types';
-import { ArrayField, CheckboxField, DividerField, DropdownField, HiddenField, IntegerField, LabelField, MultiCheckboxField, MultiSelectField, ObjectField, RadioField, TextAreaField, TextField } from './fields';
+import {
+    ArrayField,
+    CheckboxField,
+    DividerField,
+    DropdownField,
+    HiddenField,
+    IntegerField,
+    LabelField,
+    MultiCheckboxField,
+    MultiSelectField,
+    ObjectField,
+    RadioField,
+    TextAreaField,
+    TextField,
+} from './fields';
 import { zodValidationPresets } from './zodValidationsPresets';
 
 const defaultComponentMatchers: PydanticComponentMatcher[] = [
@@ -122,7 +137,7 @@ const defaultComponentMatchers: PydanticComponentMatcher[] = [
             isControlledElement: true,
         },
         matcher(field) {
-            const fieldOptions = field.arrayItem?.options
+            const fieldOptions = field.arrayItem?.options;
 
             return (
                 field.type === PydanticFormFieldType.ARRAY &&
@@ -140,7 +155,7 @@ const defaultComponentMatchers: PydanticComponentMatcher[] = [
             isControlledElement: true,
         },
         matcher(field) {
-            const fieldOptions = field.arrayItem?.options
+            const fieldOptions = field.arrayItem?.options;
 
             return (
                 _.isArray(fieldOptions) &&

--- a/frontend/packages/pydantic-forms/src/components/fields/MultiCheckboxField.tsx
+++ b/frontend/packages/pydantic-forms/src/components/fields/MultiCheckboxField.tsx
@@ -5,9 +5,7 @@
  */
 import React from 'react';
 
-import {
-    PydanticFormControlledElementProps
-} from '../../types';
+import { PydanticFormControlledElementProps } from '../../types';
 
 export const MultiCheckboxField = ({
     value,

--- a/frontend/packages/pydantic-forms/src/components/fields/MultiCheckboxField.tsx
+++ b/frontend/packages/pydantic-forms/src/components/fields/MultiCheckboxField.tsx
@@ -18,8 +18,9 @@ export const MultiCheckboxField = ({
     const { arrayItem, id } = pydanticFormField;
     const options = arrayItem?.options;
 
+    const currentValue = (value as string[]) ?? [];
+
     const handleCheckboxChange = (optionId: string, optionValue: string) => {
-        const currentValue = value as string[];
         const newValue = currentValue.includes(optionValue)
             ? currentValue.filter((item) => item !== optionValue)
             : [...currentValue, optionValue];
@@ -41,7 +42,7 @@ export const MultiCheckboxField = ({
                             id={optionId}
                             name={optionId}
                             value={option.value}
-                            checked={(value as string[]).includes(option.value)}
+                            checked={currentValue.includes(option.value)}
                             onChange={() =>
                                 handleCheckboxChange(optionId, option.value)
                             }

--- a/frontend/packages/pydantic-forms/src/components/fields/MultiCheckboxField.tsx
+++ b/frontend/packages/pydantic-forms/src/components/fields/MultiCheckboxField.tsx
@@ -6,8 +6,7 @@
 import React from 'react';
 
 import {
-    PydanticFormControlledElementProps,
-    PydanticFormFieldOption,
+    PydanticFormControlledElementProps
 } from '../../types';
 
 export const MultiCheckboxField = ({
@@ -30,7 +29,7 @@ export const MultiCheckboxField = ({
 
     return (
         <div>
-            {options?.map((option: PydanticFormFieldOption) => {
+            {options?.map((option) => {
                 // Extract the unique ID for this option
                 const optionId = `${id}-${option.value}`;
 

--- a/frontend/packages/pydantic-forms/src/components/fields/MultiCheckboxField.tsx
+++ b/frontend/packages/pydantic-forms/src/components/fields/MultiCheckboxField.tsx
@@ -15,7 +15,8 @@ export const MultiCheckboxField = ({
     onChange,
     pydanticFormField,
 }: PydanticFormControlledElementProps) => {
-    const { options, id } = pydanticFormField;
+    const { arrayItem, id } = pydanticFormField;
+    const options = arrayItem?.options;
 
     const handleCheckboxChange = (optionId: string, optionValue: string) => {
         const currentValue = value as string[];

--- a/frontend/packages/pydantic-forms/src/components/fields/MultiSelectField.tsx
+++ b/frontend/packages/pydantic-forms/src/components/fields/MultiSelectField.tsx
@@ -5,20 +5,17 @@
  */
 import React, { useState } from 'react';
 
-import {
-    PydanticFormControlledElementProps,
-    PydanticFormFieldOption,
-} from '../../types';
 
+
+import { PydanticFormControlledElementProps, PydanticFormFieldOption } from '../../types';
 export const MultiSelectField = ({
     value,
     onChange,
     onBlur,
     disabled,
     pydanticFormField,
-}: PydanticFormControlledElementProps & {
-    options?: Array<{ value: string; label: string }>;
-}) => {
+}: PydanticFormControlledElementProps) => {
+    const options = pydanticFormField?.arrayItem?.options || [];
     const [multiSelectItems, setMultiSelectItems] = useState(value || []);
 
     return (
@@ -38,13 +35,11 @@ export const MultiSelectField = ({
                 }}
                 multiple
             >
-                {pydanticFormField.options?.map(
-                    (option: PydanticFormFieldOption) => (
-                        <option key={option.value} value={option.value}>
-                            {option.label}
-                        </option>
-                    ),
-                )}
+                {options?.map((option: PydanticFormFieldOption) => (
+                    <option key={option.value} value={option.value}>
+                        {option.label}
+                    </option>
+                ))}
             </select>
         </div>
     );

--- a/frontend/packages/pydantic-forms/src/components/fields/MultiSelectField.tsx
+++ b/frontend/packages/pydantic-forms/src/components/fields/MultiSelectField.tsx
@@ -5,9 +5,11 @@
  */
 import React, { useState } from 'react';
 
+import {
+    PydanticFormControlledElementProps,
+    PydanticFormFieldOption,
+} from '../../types';
 
-
-import { PydanticFormControlledElementProps, PydanticFormFieldOption } from '../../types';
 export const MultiSelectField = ({
     value,
     onChange,

--- a/frontend/packages/pydantic-forms/src/components/zodValidationsPresets.ts
+++ b/frontend/packages/pydantic-forms/src/components/zodValidationsPresets.ts
@@ -9,7 +9,53 @@
  */
 import { z } from 'zod';
 
+
+
 import { PydanticFormZodValidationPresets } from '../types';
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 // to prevent duplicate code in components that have (almost)the same validation
 export const zodValidationPresets: PydanticFormZodValidationPresets = {
@@ -97,16 +143,16 @@ export const zodValidationPresets: PydanticFormZodValidationPresets = {
         return validationRule;
     },
     multiSelect: (field) => {
-        const { minimum, maximum } = field?.validations ?? {};
+        const { minItems, maxItems } = field?.validations ?? {};
 
         let validationRule = z.array(z.boolean());
 
-        if (minimum) {
-            validationRule = validationRule.min(minimum);
+        if (minItems) {
+            validationRule = validationRule.min(minItems);
         }
 
-        if (maximum) {
-            validationRule = validationRule.max(maximum);
+        if (maxItems) {
+            validationRule = validationRule.max(maxItems);
         }
 
         return validationRule;

--- a/frontend/packages/pydantic-forms/src/components/zodValidationsPresets.ts
+++ b/frontend/packages/pydantic-forms/src/components/zodValidationsPresets.ts
@@ -9,53 +9,7 @@
  */
 import { z } from 'zod';
 
-
-
 import { PydanticFormZodValidationPresets } from '../types';
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 // to prevent duplicate code in components that have (almost)the same validation
 export const zodValidationPresets: PydanticFormZodValidationPresets = {
@@ -145,7 +99,7 @@ export const zodValidationPresets: PydanticFormZodValidationPresets = {
     multiSelect: (field) => {
         const { minItems, maxItems } = field?.validations ?? {};
 
-        let validationRule = z.array(z.boolean());
+        let validationRule = z.array(z.string());
 
         if (minItems) {
             validationRule = validationRule.min(minItems);

--- a/frontend/packages/pydantic-forms/src/components/zodValidationsPresets.ts
+++ b/frontend/packages/pydantic-forms/src/components/zodValidationsPresets.ts
@@ -96,19 +96,4 @@ export const zodValidationPresets: PydanticFormZodValidationPresets = {
 
         return validationRule;
     },
-    multiSelect: (field) => {
-        const { minItems, maxItems } = field?.validations ?? {};
-
-        let validationRule = z.array(z.string());
-
-        if (minItems) {
-            validationRule = validationRule.min(minItems);
-        }
-
-        if (maxItems) {
-            validationRule = validationRule.max(maxItems);
-        }
-
-        return validationRule;
-    },
 };

--- a/frontend/packages/pydantic-forms/src/core/helper.spec.ts
+++ b/frontend/packages/pydantic-forms/src/core/helper.spec.ts
@@ -30,7 +30,6 @@ export const getMockPydanticFormField = (
         arrayItem: undefined,
         properties: {},
         required: false,
-        options: [],
         schema: {
             type: PydanticFormFieldType.STRING,
             format: PydanticFormFieldFormat.DEFAULT,

--- a/frontend/packages/pydantic-forms/src/core/helper.ts
+++ b/frontend/packages/pydantic-forms/src/core/helper.ts
@@ -5,18 +5,7 @@
  */
 import { FieldValues } from 'react-hook-form';
 
-import {
-    Properties,
-    PydanticFormContextConfig,
-    PydanticFormField,
-    PydanticFormFieldAttributes,
-    PydanticFormFieldOption,
-    PydanticFormFieldType,
-    PydanticFormFieldValidations,
-    PydanticFormPropertySchemaParsed,
-    PydanticFormSchema,
-    PydanticFormValidationResponse,
-} from '../types';
+import { Properties, PydanticFormContextConfig, PydanticFormField, PydanticFormFieldAttributes, PydanticFormFieldOption, PydanticFormFieldType, PydanticFormFieldValidations, PydanticFormPropertySchemaParsed, PydanticFormSchema, PydanticFormValidationResponse } from '../types';
 import { getPydanticFormComponents } from './getPydanticFormComponents';
 
 /**
@@ -137,11 +126,11 @@ export const getFieldOptions = (
     const options: PydanticFormFieldOption[] = [];
 
     // NOTE: enum is the property described in the JSON Schema specification that stores possible values for a field.
-    // .options is a custom property that left here for backwards compatibility.
+    // .options is a custom property left here for backwards compatibility.
     const propertyEnums =
-        propertySchemaParsed.enum ?? propertySchemaParsed.items?.enum;
+        propertySchemaParsed.enum
     const propertyOptions =
-        propertySchemaParsed.options ?? propertySchemaParsed.items?.options;
+        propertySchemaParsed.options
 
     if (propertyEnums && !propertyOptions) {
         options.push(...enumToOption(propertyEnums));
@@ -235,6 +224,8 @@ export const getFieldValidation = (
         validation.isNullable = true;
     }
     const {
+        maxItems,
+        minItems,
         maxLength,
         minLength,
         pattern,
@@ -244,8 +235,6 @@ export const getFieldValidation = (
         exclusiveMaximum,
         exclusiveMinimum,
         multipleOf,
-        minItems,
-        maxItems,
         uniqueItems,
     } = schema;
 
@@ -265,8 +254,9 @@ export const getFieldValidation = (
         if (multipleOf) validation.multipleOf = multipleOf;
     }
     if (type === PydanticFormFieldType.ARRAY) {
-        validation.minItems = minItems;
         validation.maxItems = maxItems;
+        validation.maxItems = maxItems;
+        validation.minItems = minItems;
         validation.uniqueItems = uniqueItems;
     }
 

--- a/frontend/packages/pydantic-forms/src/core/helper.ts
+++ b/frontend/packages/pydantic-forms/src/core/helper.ts
@@ -5,7 +5,18 @@
  */
 import { FieldValues } from 'react-hook-form';
 
-import { Properties, PydanticFormContextConfig, PydanticFormField, PydanticFormFieldAttributes, PydanticFormFieldOption, PydanticFormFieldType, PydanticFormFieldValidations, PydanticFormPropertySchemaParsed, PydanticFormSchema, PydanticFormValidationResponse } from '../types';
+import {
+    Properties,
+    PydanticFormContextConfig,
+    PydanticFormField,
+    PydanticFormFieldAttributes,
+    PydanticFormFieldOption,
+    PydanticFormFieldType,
+    PydanticFormFieldValidations,
+    PydanticFormPropertySchemaParsed,
+    PydanticFormSchema,
+    PydanticFormValidationResponse,
+} from '../types';
 import { getPydanticFormComponents } from './getPydanticFormComponents';
 
 /**
@@ -127,10 +138,8 @@ export const getFieldOptions = (
 
     // NOTE: enum is the property described in the JSON Schema specification that stores possible values for a field.
     // .options is a custom property left here for backwards compatibility.
-    const propertyEnums =
-        propertySchemaParsed.enum
-    const propertyOptions =
-        propertySchemaParsed.options
+    const propertyEnums = propertySchemaParsed.enum;
+    const propertyOptions = propertySchemaParsed.options;
 
     if (propertyEnums && !propertyOptions) {
         options.push(...enumToOption(propertyEnums));
@@ -254,9 +263,8 @@ export const getFieldValidation = (
         if (multipleOf) validation.multipleOf = multipleOf;
     }
     if (type === PydanticFormFieldType.ARRAY) {
-        validation.maxItems = maxItems;
-        validation.maxItems = maxItems;
         validation.minItems = minItems;
+        validation.maxItems = maxItems;
         validation.uniqueItems = uniqueItems;
     }
 

--- a/frontend/packages/pydantic-forms/src/core/hooks/hooks.spec.ts
+++ b/frontend/packages/pydantic-forms/src/core/hooks/hooks.spec.ts
@@ -350,7 +350,8 @@ describe('getZodValidationObject', () => {
         );
 
         const expectedZodObject = z.object({
-            uncontrolled: z.array(z.any()),
+            // The array field is not marked required so the rule is optional
+            uncontrolled: z.array(z.any()).optional(),
         });
 
         expect(z.toJSONSchema(schema)).toEqual(

--- a/frontend/packages/pydantic-forms/src/core/hooks/useGetZodSchema.tsx
+++ b/frontend/packages/pydantic-forms/src/core/hooks/useGetZodSchema.tsx
@@ -39,25 +39,42 @@ export const getZodRule = (
         const arrayItemRule = arrayItem
             ? getZodRule(arrayItem, componentMatcher)
             : z.any();
-        const arrayRule = z
-            .array(arrayItemRule || z.unknown())
-            .superRefine((array, context) => {
-                const { uniqueItems } = pydanticFormField.validations;
 
-                if (uniqueItems) {
-                    const uniqueArray = [...new Set(array)];
+        const { minItems, maxItems, uniqueItems } =
+            pydanticFormField.validations;
 
-                    if (uniqueArray.length !== array.length) {
-                        context.addIssue({
-                            code: z.ZodIssueCode.custom,
-                            message: 'not_unique',
-                            fatal: true,
-                        });
-                        return z.NEVER;
-                    }
-                }
+        let arrayRule = z.array(arrayItemRule || z.unknown());
+
+        if (minItems) {
+            arrayRule = arrayRule.min(minItems, {
+                error: `Too small: expected array to have >= ${minItems} items`,
             });
-        return arrayRule;
+        }
+
+        if (maxItems) {
+            arrayRule = arrayRule.max(maxItems, {
+                error: `Too big: expected array to have <= ${maxItems} items`,
+            });
+        }
+
+        const refinedArrayRule = arrayRule.superRefine((array, context) => {
+            if (uniqueItems) {
+                const uniqueArray = [...new Set(array)];
+
+                if (uniqueArray.length !== array.length) {
+                    context.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        message: 'not_unique',
+                        fatal: true,
+                    });
+                    return z.NEVER;
+                }
+            }
+        });
+
+        return pydanticFormField.required
+            ? refinedArrayRule
+            : refinedArrayRule.optional();
     }
 
     return getClientSideValidationRule(pydanticFormField, componentMatcher);

--- a/frontend/packages/pydantic-forms/src/core/hooks/usePydanticFormParser.tsx
+++ b/frontend/packages/pydantic-forms/src/core/hooks/usePydanticFormParser.tsx
@@ -84,7 +84,6 @@ const getPydanticFormField = (
     const addConstValue =
         typeof flatSchema.const === 'undefined' ? false : true;
 
-
     //TODO: I think object properties should never be required only their properties are or aren't. Should we fix this in the backend?
     const required =
         flatSchema.type === PydanticFormFieldType.OBJECT

--- a/frontend/packages/pydantic-forms/src/core/hooks/usePydanticFormParser.tsx
+++ b/frontend/packages/pydantic-forms/src/core/hooks/usePydanticFormParser.tsx
@@ -51,7 +51,6 @@ const getPydanticFormField = (
     // This solves the case where the propertySchema only contains an anyOf, allOf or oneOf entry and no other properties
     // TODO: Possibly add a case for when there are multiple fieldOptionsEntries
     const options = getFieldOptions(flatSchema);
-
     const validations = getFieldValidation(flatSchema);
     const attributes = getFieldAttributes(flatSchema);
     const properties = parseProperties(
@@ -85,10 +84,6 @@ const getPydanticFormField = (
     const addConstValue =
         typeof flatSchema.const === 'undefined' ? false : true;
 
-    // Don't add options to array items if they have an arrayItem where they live
-    const addOptions = !(
-        flatSchema.type === PydanticFormFieldType.ARRAY && arrayItem
-    );
 
     //TODO: I think object properties should never be required only their properties are or aren't. Should we fix this in the backend?
     const required =
@@ -103,7 +98,7 @@ const getPydanticFormField = (
         arrayItem,
         format: flatSchema.format || PydanticFormFieldFormat.DEFAULT,
         type: flatSchema.type || PydanticFormFieldType.STRING,
-        ...toOptionalObjectProperty({ options }, addOptions),
+        ...toOptionalObjectProperty({ options }, options.length > 0),
         default: flatSchema.default,
         attributes: attributes,
         schema: propertySchema,


### PR DESCRIPTION
Fixes the way a fields options are retrieved from the JSON schema form definition in case of array type fields. They were hoisted from the items property and are left on the item level now. This makes it possible to fix a bug in the way  multi checkbox and multi select components are matched and fixes the frontend validations applied to them.